### PR TITLE
CI: update test container

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -36,7 +36,7 @@ variables:
 resources:
   containers:
     - container: default
-      image: quay.io/ansible/azure-pipelines-test-container:3.0.0
+      image: quay.io/ansible/azure-pipelines-test-container:4.0.1
 
 pool: Standard
 


### PR DESCRIPTION
ansible-core devel is dropping controller support for Python 3.9, we need to update the base container to a newer version.

See https://github.com/ansible-collections/news-for-maintainers/issues/49